### PR TITLE
Update device URL to fix 410 error

### DIFF
--- a/sharkiqpy/const.py
+++ b/sharkiqpy/const.py
@@ -1,6 +1,6 @@
 """Various constants"""
 
-DEVICE_URL = "https://ads-field.aylanetworks.com"
+DEVICE_URL = "https://ads-apiv1-sharkue1.aylanetworks.com"
 LOGIN_URL = "https://user-field.aylanetworks.com"
 SHARK_APP_ID = "Shark-Android-field-id"
 SHARK_APP_SECRET = "Shark-Android-field-Wv43MbdXRM297HUHotqe6lU1n-w"


### PR DESCRIPTION
TL;DR: Update URL to fix broken stuff.
-----------

Recently this library (and the dependent Home Assistant integration) appears to have been broken by some changes to the Ayla API. As noted [here](https://github.com/home-assistant/core/issues/44775#issuecomment-1027061596) and [here](https://github.com/home-assistant/core/issues/65367). 

Requests to the old `DEVICE_URL` seem to be returning a 410 error (e.g. when calling `AylaApi.get_devices()`):
```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    shark_vacs = ayla_api.get_devices()
  File "/home/travipross/git/external/sharkiq/sharkiqpy/ayla_api.py", line 205, in get_devices
    devices = [SharkIqVacuum(self, d) for d in self.list_devices()]
  File "/home/travipross/git/external/sharkiq/sharkiqpy/ayla_api.py", line 192, in list_devices
    devices = resp.json()
  File "/home/travipross/.pyenv/versions/shark/lib/python3.7/site-packages/requests/models.py", line 900, in json
    return complexjson.loads(self.text, **kwargs)
  File "/home/travipross/.pyenv/versions/3.7.7/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/home/travipross/.pyenv/versions/3.7.7/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/home/travipross/.pyenv/versions/3.7.7/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
 I just set a breakpoint to step through the problem, and I found the [response to the request that fetches the list of devices](https://github.com/ajmarks/sharkiq/blob/c2b12020af287c059b3d4a467d15dcfaa4f14430/sharkiqpy/ayla_api.py#L191) was coming back with `resp.status_code=410` and `resp.text=This resource is not available over http`. Not really sure if the error text is super relevant here, but there's no JSON in that response payload, hence the uncaught exception. 

I honestly can't remember exactly where I got this new URL with complete certainty, but I was able to find it in my terminal history from back when I was messing around with `curl` against the API. 

A while back I had been stepping through the API, hitting the `/devices/<id>/properties` endpoint to see if I could figure out how to extract map data. Well at the time, I think I had spotted the property `GET_Visual_Floor_1`, and noticed it had a `value` field which contained an Ayla API URL. At the time I had thankfully tried to hit that URL (unfortunately without any luck; I could download a file but not make any sense of it), which left it in my shell history.
```json
{
    "property": {
      "type": "Property",
      "name": "GET_Visual_Floor_1",
      "base_type": "file",
      "read_only": true,
      "direction": "output",
      "scope": "user",
      "data_updated_at": "2022-01-03T18:03:34Z",
      "key": 12345678,
      "device_key": 87654321,
      "product_name": "Jaws",
      "track_only_changes": false,
      "display_name": "Visual Floor 1",
      "host_sw_version": false,
      "time_series": false,
      "derived": false,
      "app_type": null,
      "recipe": null,
      "value": "https://ads-apiv1-sharkue1.aylanetworks.com/apiv1/devices/12345678/properties/GET_Visual_Floor_1/datapoints/12341234-12324-1234-1234-123412341234.json",
      "generated_from": null,
      "generated_at": null,
      "denied_roles": [],
      "ack_enabled": false,
      "retention_days": 30
    }
``` 

I didn't realize until today that the subdomain of aylanetworks.com was different than the `DEVICE_URL` from `sharkiq` I had originally used to fetch this property payload. Sure enough, if I use that domain as the `DEVICE_URL` with `sharkiq`, it can successfully list my devices and access the methods as expected.

Perhaps the folks at Shark/Ayla had migrated some device functionality over to a new URL, and I was just lucky enough to catch it as part of a response during some transitional period where both URLs were live, but the new one was being returned in property payloads.

Nonetheless, I believe this should fix the issues over at the [Home Assistant repo](https://github.com/home-assistant/core/issues/65367).